### PR TITLE
[WIP] Adding validator decorator and moving to Marshmallow 2

### DIFF
--- a/qiskit/models/backend_status.py
+++ b/qiskit/models/backend_status.py
@@ -10,10 +10,10 @@
 from marshmallow.fields import String, Boolean, Integer
 from marshmallow.validate import Range, Regexp
 
-from .base import BaseModel, BaseSchema
+from .base import ModelSchema, bind_schema, BaseModel
 
 
-class BackendStatusSchema(BaseSchema):
+class BackendStatusSchema(ModelSchema):
     """Schema for BackendStatus."""
 
     # Required fields.
@@ -26,6 +26,7 @@ class BackendStatusSchema(BaseSchema):
     status_msg = String(required=True)
 
 
+@bind_schema(BackendStatusSchema)
 class BackendStatus(BaseModel):
     """Backend Status."""
 

--- a/qiskit/models/base.py
+++ b/qiskit/models/base.py
@@ -38,7 +38,11 @@ class ModelSchema(Schema):
 
         Args:
             valid_data (dict): data collected and returned by ``dump()``.
-            original_data (object): object passed to ``dump()`` in the first place.
+            original_data (object): object passed to ``dump()`` in the first
+            place.
+
+        Returns:
+            dict: the same ``valid_data`` extended with the unknown attributes.
 
         Inspired by https://github.com/marshmallow-code/marshmallow/pull/595.
         """
@@ -56,6 +60,9 @@ class ModelSchema(Schema):
         Args:
             valid_data (dict): validated data returned by ``load()``.
             original_data (dict): data passed to ``load()`` in the first place.
+
+        Returns:
+            dict: the same ``valid_data`` extended with the unknown attributes.
 
         From https://github.com/marshmallow-code/marshmallow/pull/595.
         """

--- a/qiskit/models/base.py
+++ b/qiskit/models/base.py
@@ -5,7 +5,11 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-"""Building blocks for schema validations."""
+"""Building blocks for Qiskit validated classes.
+
+The module contains base classes for validated classes and schemas and the
+``bind_schema`` decorator to orchestrate them."""
+
 from functools import wraps
 from types import SimpleNamespace
 
@@ -14,15 +18,27 @@ from marshmallow import Schema, post_dump, post_load
 
 
 class ModelSchema(Schema):
+    """Provide deserialization into class instances instead of dicts.
+
+    Conveniently for the Qiskit common case, this class also loads and dumps
+    unknown attributes not defined in the schema.
+
+    Attributes:
+         model_cls (type): class used to instantiate the instance. The
+         constructor is passed all named parameters from deserialization.
+    """
 
     model_cls = SimpleNamespace
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     @post_dump(pass_original=True)
     def dump_additional_data(self, valid_data, original_data):
-        """Allow including unknown fields in the deserialized result.
+        """Include unknown fields after dumping.
+
+        Unknown fields are added with no processing at all.
+
+        Args:
+            valid_data (dict): data collected and returned by ``dump()``.
+            original_data (object): object passed to ``dump()`` in the first place.
 
         Inspired by https://github.com/marshmallow-code/marshmallow/pull/595.
         """
@@ -33,7 +49,16 @@ class ModelSchema(Schema):
 
     @post_load(pass_original=True)
     def load_additional_data(self, valid_data, original_data):
-        # From https://github.com/marshmallow-code/marshmallow/pull/595.
+        """Include unknown fields after load.
+
+        Unknown fields are added with no processing at all.
+
+        Args:
+            valid_data (dict): validated data returned by ``load()``.
+            original_data (dict): data passed to ``load()`` in the first place.
+
+        From https://github.com/marshmallow-code/marshmallow/pull/595.
+        """
 
         additional_keys = set(original_data) - set(valid_data)
         for key in additional_keys:
@@ -42,45 +67,66 @@ class ModelSchema(Schema):
 
     @post_load
     def make_model(self, data):
+        """Make ``load`` to return an instance of ``model_cls`` instead of a dict.
+        """
         return self.model_cls(**data)
 
 
-class BindSchema:
+class _BindSchema:
+    """Aux class to implement the parametrized decorator ``bind_schema``.
+
+    TODO:
+        - Raise if trying to bind a schema more than once.
+    """
 
     def __init__(self, schema):
+        """Get the schema for the decorated model."""
         self._schema = schema
 
-    def __call__(self, cls):
-        self._schema.model_cls = cls
-        cls.schema = self._schema()
-        cls.to_dict = self._to_dict
-        cls.from_dict = classmethod(self._from_dict)
-        cls.__init__ = self._validate_after_init(cls.__init__)
-        return cls
+    def __call__(self, model_cls):
+        """Augment the model class with the validation API.
+
+        See the docs for ``bind_schema`` for further information.
+        """
+        self._schema.model_cls = model_cls
+        model_cls.schema = self._schema()
+        model_cls._validate = self._validate
+        model_cls.to_dict = self._to_dict
+        model_cls.from_dict = classmethod(self._from_dict)
+        model_cls.__init__ = self._validate_after_init(model_cls.__init__)
+        return model_cls
 
     @staticmethod
-    def _to_dict(self):
-        data, errors = self.schema.dump(self)
+    def _to_dict(instance):
+        """Serialize the model into a Python dict of simple types."""
+        data, errors = instance.schema.dump(instance)
         if errors:
             raise ValidationError(errors)
         return data
 
     @staticmethod
-    def _from_dict(cls, dct):
-        data, errors = cls.schema.load(dct)
+    def _validate(instance):
+        """Validate the internal representation of the instance."""
+        errors = instance.schema.validate(instance.to_dict())
+        if errors:
+            raise ValidationError(errors)
+
+    @staticmethod
+    def _from_dict(decorated_cls, dct):
+        """Deserialize a dict of simple types into an instance of this class."""
+        data, errors = decorated_cls.schema.load(dct)
         if errors:
             raise ValidationError(errors)
         return data
 
     @staticmethod
     def _validate_after_init(init_method):
+        """Add validation after instantiation."""
 
         @wraps(init_method)
         def _decorated(self, *args, **kwargs):
             init_method(self, *args, **kwargs)
-            errors = self.schema.validate(self.to_dict())
-            if errors:
-                raise ValidationError(errors)
+            self._validate()
 
         _decorated._validating = False
 
@@ -88,7 +134,22 @@ class BindSchema:
 
 
 class BaseModel(SimpleNamespace):
+    """Root class for validated Qiskit classes."""
     pass
 
+
 def bind_schema(schema):
-    return BindSchema(schema)
+    """By decorating a class, it adds schema validation to its instances.
+
+    Instances of the decorated class are automatically validated after
+    instantiation and they are augmented to allow further validations with the
+    private method ``_validate()``.
+
+    The decorator also adds the class attribute ``schema`` with the schema used
+    for validation.
+
+    To ease serialization/deserialization to/from simple Python objects,
+    classes are provided with ``to_dict`` and ``from_dict`` instance and class
+    methods respectively.
+    """
+    return _BindSchema(schema)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 jsonschema>=2.6,<2.7
-marshmallow>=3.0.0b20
+marshmallow>=2.16.3,<3
 matplotlib>=2.1
 networkx>=2.0
 numpy>=1.13

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools.dist import Distribution
 
 requirements = [
     "jsonschema>=2.6,<2.7",
-    "marshmallow>=3.0.0b20",
+    "marshmallow>=2.16.3,<3",
     "matplotlib>=2.1",
     "networkx>=2.0",
     "numpy>=1.13",

--- a/test/python/test_models.py
+++ b/test/python/test_models.py
@@ -10,30 +10,32 @@
 
 from marshmallow import fields, ValidationError
 
-from qiskit.models.base import BaseModel, BaseSchema
+from qiskit.models.base import BaseModel, ModelSchema, bind_schema
 from .common import QiskitTestCase
 
 
-class PersonSchema(BaseSchema):
+class PersonSchema(ModelSchema):
     """Example Person schema."""
     name = fields.String(required=True)
 
 
-class BookSchema(BaseSchema):
+class BookSchema(ModelSchema):
     """Example Book schema."""
     title = fields.String(required=True)
     date = fields.Date()
     author = fields.Nested(PersonSchema, required=True)
 
 
+@bind_schema(PersonSchema)
 class Person(BaseModel):
     """Example Person model."""
-    schema_cls = PersonSchema
+    pass
 
 
+@bind_schema(BookSchema)
 class Book(BaseModel):
     """Example Book model."""
-    schema_cls = BookSchema
+    pass
 
 
 class ModelsTest(QiskitTestCase):


### PR DESCRIPTION
Done:
- Switched to `marshmallow 2.16.3`.
- Adapted implementation to use `marshmallow 2`
- Added `bind_schema` decorator.

Remains:
- [ ] Documenting `ModelSchema` and `bind_schema`.